### PR TITLE
Backport RTD docs changes to enable docs for v0.2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,5 +17,3 @@ python:
       - requirements: requirements_docs.txt
       - method: pip
         path: .
-      - method: setuptools
-        path: package

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build configuration
+python:
+   version: 3.7
+   install:
+      - requirements: requirements.txt
+      - requirements: requirements_docs.txt
+      - method: pip
+        path: .
+      - method: setuptools
+        path: package

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,8 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+# Override master_doc from `contents` to `index`
+master_doc = 'index'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@
 # -- Project information -----------------------------------------------------
 
 project = "Frigate"
-copyright = "2019, Jacob Tomlinson"
-author = "Jacob Tomlinson"
+copyright = "2020, NVIDIA"
+author = "RAPIDS"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -44,7 +44,7 @@ of the list.
      - name: "USERNAME"
        value: "app-username"
 
-.. code-block::
+.. code-block:: md
 
    | Parameter                | Description             | Default        |
    | ------------------------ | ----------------------- | -------------- |


### PR DESCRIPTION
Backports #6 to master so docs are available for the latest stable as well.