### PR TITLE
[REVIEW] Update CI scripts to remove references to master [skip ci] 

### DIFF
--- a/ci/cpu/upload-packages.sh
+++ b/ci/cpu/upload-packages.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
-# Restrict uploads to master branch
-if [[ "${GIT_BRANCH}" != "master" ]]; then
   echo "Skipping upload"
   return 0
 fi

--- a/ci/cpu/upload-packages.sh
+++ b/ci/cpu/upload-packages.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
+if [[ "${BUILD_MODE}" != "branch" ]]; then
   echo "Skipping upload"
   return 0
 fi


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.