### PR TITLE
Add options to sphinx directive

### DIFF
--- a/frigate/sphinx/ext.py
+++ b/frigate/sphinx/ext.py
@@ -2,6 +2,7 @@ import os
 
 from docutils import nodes
 from docutils.parsers import rst
+from docutils.parsers.rst.directives import unchanged
 from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
 
@@ -12,7 +13,7 @@ class FrigateDirective(rst.Directive):
     has_content = True
     required_arguments = 1
     option_spec = {
-        'output_format': str,
+        'output_format': unchanged,
     }
 
     def run(self):
@@ -20,7 +21,11 @@ class FrigateDirective(rst.Directive):
             os.getcwd(),  # TODO Need to find a better way to get the root of the docs
             self.arguments[0],
         )
-        output = ViewList(gen(chart_path, output_format=self.options.get('output_format')).split("\n"))
+        if self.options.get('output_format') == "":
+            output_format = 'rst'
+        else:
+            output_format = self.options.get('output_format')
+        output = ViewList(gen(chart_path, output_format=output_format).split("\n"))
 
         node = nodes.section()
         node.document = self.state.document

--- a/frigate/sphinx/ext.py
+++ b/frigate/sphinx/ext.py
@@ -20,7 +20,7 @@ class FrigateDirective(rst.Directive):
             os.getcwd(),  # TODO Need to find a better way to get the root of the docs
             self.arguments[0],
         )
-        output = ViewList(gen(chart_path, output_format=self.option_spec.get('output_format')).split("\n"))
+        output = ViewList(gen(chart_path, output_format=self.options.get('output_format')).split("\n"))
 
         node = nodes.section()
         node.document = self.state.document

--- a/frigate/sphinx/ext.py
+++ b/frigate/sphinx/ext.py
@@ -20,7 +20,7 @@ class FrigateDirective(rst.Directive):
             os.getcwd(),  # TODO Need to find a better way to get the root of the docs
             self.arguments[0],
         )
-        output = ViewList(gen(chart_path, output_format="rst").split("\n"))
+        output = ViewList(gen(chart_path, output_format=self.option_spec.get('output_format')).split("\n"))
 
         node = nodes.section()
         node.document = self.state.document

--- a/frigate/sphinx/ext.py
+++ b/frigate/sphinx/ext.py
@@ -9,8 +9,11 @@ from frigate.gen import gen
 
 
 class FrigateDirective(rst.Directive):
-    has_content = False
+    has_content = True
     required_arguments = 1
+    option_spec = {
+        'output_format': str,
+    }
 
     def run(self):
         chart_path = os.path.join(

--- a/frigate/sphinx/ext.py
+++ b/frigate/sphinx/ext.py
@@ -15,15 +15,14 @@ class FrigateDirective(rst.Directive):
     option_spec = {
         'output_format': unchanged,
     }
-    options = {
-        'output_format': 'rst',
-    }
 
     def run(self):
         chart_path = os.path.join(
             os.getcwd(),  # TODO Need to find a better way to get the root of the docs
             self.arguments[0],
         )
+        if self.options.get('output_format') is None:
+            self.options.update({'output_format': 'rst'})
         output = ViewList(gen(chart_path, output_format=self.options.get('output_format')).split("\n"))
 
         node = nodes.section()

--- a/frigate/sphinx/ext.py
+++ b/frigate/sphinx/ext.py
@@ -15,17 +15,16 @@ class FrigateDirective(rst.Directive):
     option_spec = {
         'output_format': unchanged,
     }
+    options = {
+        'output_format': 'rst',
+    }
 
     def run(self):
         chart_path = os.path.join(
             os.getcwd(),  # TODO Need to find a better way to get the root of the docs
             self.arguments[0],
         )
-        if self.options.get('output_format') == "":
-            output_format = 'rst'
-        else:
-            output_format = self.options.get('output_format')
-        output = ViewList(gen(chart_path, output_format=output_format).split("\n"))
+        output = ViewList(gen(chart_path, output_format=self.options.get('output_format')).split("\n"))
 
         node = nodes.section()
         node.document = self.state.document


### PR DESCRIPTION
This adds the ability to specify the output format in the sphinx directive. Tested and working with rst and markdown, though it seems to be based entirely on the available jinja templates so there's no reason to think the other templates wouldn't also work.