### PR TITLE
Bugfix for charts with dependencies and make pre-commit hook function on pre-commit.ci

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,11 @@
--   id: frigate
-    name: frigate
-    entry: frigate hook
-    description: Run frigate to generate documentation for your Helm charts.
-    language: python
-    pass_filenames: false
-    always_run: true
+# This is a pre-commit hook definition, for more details see:
+# https://pre-commit.com/#new-hooks
+#
+- id: frigate
+  name: frigate
+  entry: frigate hook
+  description: Run frigate to generate documentation for your Helm charts.
+  # language=conda relies on the environment.yml file in this repo
+  language: conda
+  pass_filenames: false
+  always_run: true

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+# These are dependencies for the pre-commit hook defined in
+# .pre-commit-hooks.yaml.
+#
+# This environment can provide `helm` via the kubernetes-helm package, but must
+# also explicitly install frigate itself within this repo.
+#
+name: pre-commit-hook-environment
+dependencies:
+  - python
+  - kubernetes-helm
+  - pip
+  - pip:
+    - "."

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,4 @@ dependencies:
   - kubernetes-helm
   - pip
   - pip:
-    - "."
+      - "."

--- a/frigate/gen.py
+++ b/frigate/gen.py
@@ -64,10 +64,11 @@ def load_chart_with_dependencies(chartdir, root=None):
                 chartdir, "charts", f"{dependency_name}-{dependency['version']}.tgz",
             )
             with tempfile.TemporaryDirectory() as tmpdirname:
+                update_chart_dependencies(tmpdirname, dependency_name)
+
                 shutil.unpack_archive(dependency_path, tmpdirname)
                 dependency_dir = os.path.join(tmpdirname, dependency_name)
 
-                update_chart_dependencies(tmpdirname, dependency_name)
                 _, dependency_values = load_chart_with_dependencies(
                     dependency_dir, root + [dependency_name]
                 )

--- a/frigate/gen.py
+++ b/frigate/gen.py
@@ -116,12 +116,6 @@ def update_chart_dependencies(path, chart_name):
             "value table entried for dependencies."
         )
     subprocess.check_call(
-        ["helm", "repo", "update"],
-        cwd=path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    subprocess.check_call(
         ["helm", "dep", "update", chart_name],
         cwd=path,
         stdout=subprocess.PIPE,

--- a/frigate/gen.py
+++ b/frigate/gen.py
@@ -95,7 +95,7 @@ def squash_duplicate_values(values):
     return [(key, tmp[key][0], tmp[key][1]) for key in tmp]
 
 
-def update_chart_dependencies(path, chart_name):
+def update_chart_dependencies(chart_path):
     """Update a helm charts local cache of dependencies.
 
     In order to generate a values table including dependencies we need
@@ -103,8 +103,8 @@ def update_chart_dependencies(path, chart_name):
     values for we will call ``helm dep update <chart>``.
 
     Args:
-        path (string): Path to the directory containing the helm chart.
-        chart_name (string): The name of the chart to update dependencies for.
+        chart_path (string): Path to the directory containing the helm chart
+                             with dependencies to update to its charts/ folder.
 
     """
     if shutil.which("helm") is None:
@@ -115,8 +115,8 @@ def update_chart_dependencies(path, chart_name):
             "value table entried for dependencies."
         )
     subprocess.check_call(
-        ["helm", "dep", "update", chart_name],
-        cwd=path,
+        ["helm", "dep", "update", "."],
+        cwd=chart_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )

--- a/frigate/gen.py
+++ b/frigate/gen.py
@@ -58,14 +58,13 @@ def load_chart_with_dependencies(chartdir, root=None):
     root = [] if root is None else root
     chart, values = load_chart(chartdir, root=root)
     if "dependencies" in chart:
+        update_chart_dependencies(chartdir)
         for dependency in chart["dependencies"]:
             dependency_name = dependency["name"]
             dependency_path = os.path.join(
                 chartdir, "charts", f"{dependency_name}-{dependency['version']}.tgz",
             )
             with tempfile.TemporaryDirectory() as tmpdirname:
-                update_chart_dependencies(tmpdirname, dependency_name)
-
                 shutil.unpack_archive(dependency_path, tmpdirname)
                 dependency_dir = os.path.join(tmpdirname, dependency_name)
 

--- a/frigate/gen.py
+++ b/frigate/gen.py
@@ -114,18 +114,18 @@ def update_chart_dependencies(path, chart_name):
             "Alternatively run frigate again with the `--no-deps` flag to skip generating "
             "value table entried for dependencies."
         )
-    subprocess.Popen(
+    subprocess.check_call(
         ["helm", "repo", "update"],
         cwd=path,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-    ).communicate()
-    subprocess.Popen(
+    )
+    subprocess.check_call(
         ["helm", "dep", "update", chart_name],
         cwd=path,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-    ).communicate()
+    )
     return None
 
 

--- a/frigate/gen.py
+++ b/frigate/gen.py
@@ -22,7 +22,7 @@ def load_chart(chartdir, root=None):
 
     Args:
         chartdir (str): Path to the Helm chart.
-        root (str, optional): The root of the namespace we are currently at. Used for recursion.
+        root (list, optional): The root of the namespace we are currently at. Used for recursion.
 
     Returns:
         chart (dict): Contents of `Chart.yaml` loaded into a dict.
@@ -37,28 +37,27 @@ def load_chart(chartdir, root=None):
 
 
 def load_chart_with_dependencies(chartdir, root=None):
-    """Load the yaml information from a Helm chart directory and its dependencies.
-
-    Load in the `Chart.yaml` and `values.yaml` files from a Helm
-    chart.
-
-    Inspect the `Chart.yaml` and if there are dependencies unpack their
-    `values.yaml` and `Chart.yaml` and merge the values. Recur for all
-    dependencies.
+    """
+    Load and return dictionaries representing Chart.yaml and values.yaml from
+    the Helm chart. If Chart.yaml declares dependencies, recursively merge in
+    their values as well.
 
     Args:
         chartdir (str): Path to the Helm chart.
-        root (str, optional): The root of the namespace we are currently at. Used for recursion.
+        root (list, optional): The root of the namespace we are currently at. Used for recursion.
 
     Returns:
         chart (dict): Contents of `Chart.yaml` loaded into a dict.
         values (dict): Contents of `values.yaml` loaded into a dict.
-
     """
-    root = [] if root is None else root
+    if root is None:
+        root = []
     chart, values = load_chart(chartdir, root=root)
     if "dependencies" in chart:
+        # update the helm chart's charts/ folder
         update_chart_dependencies(chartdir)
+
+        # recursively update values by unpacking the helm charts in the charts/ folder
         for dependency in chart["dependencies"]:
             dependency_name = dependency["name"]
             dependency_path = os.path.join(
@@ -200,7 +199,7 @@ def traverse(tree, root=None):
 
     Args:
         comment (ruamel.yaml.comments.CommentedMap): Tree of config to traverse.
-        root (str, optional): The root of the namespace we are currently at. Used for recursion.
+        root (list, optional): The root of the namespace we are currently at. Used for recursion.
 
     Yields:
         list(param, comment, value): Each namespaced parameter (str), the comment (str) and value (obj).


### PR DESCRIPTION
The changes in this PR:
- fixed a bug about running `helm dep up .` too late
- removed a call to `helm repo update` that isn't relevant for `helm dep up .` as `helm dep up .` will get the helm chart repo as defined in the dependencies list no matter what.
- made the defined pre-commit hook function on pre-commit.ci by setting up a conda environment that installs `helm`

Please feel free to push commits directly to this PR or close it and use it as inspiration etc.

---

I've tested using pre-commit against a fork with these changes and it works even though I didn't have `helm` available or content in a `charts/` folder pre-populated.
