### PR TITLE
Remove compiler variables

### DIFF
--- a/conda/recipes/frigate/meta.yaml
+++ b/conda/recipes/frigate/meta.yaml
@@ -14,10 +14,6 @@ build:
   number: {{ git_revision_count }}
   script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   noarch: python
-  script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
   build:


### PR DESCRIPTION
With the PR below merged, we no longer set the `CXX`, `CC`, or `CUDAHOSTCXX` variables in any of our CI images. This PR cleans up some references to them.


- https://github.com/rapidsai/gpuci-build-environment/pull/265


I don't think these variables were relevant to `frigate` anyway since it's just a Python tool.