### PR TITLE
skip deps refreshes on test which are local anyway

### DIFF
--- a/frigate/pre_commit_hook.py
+++ b/frigate/pre_commit_hook.py
@@ -45,7 +45,7 @@ def main(output_file, format, credits=True, deps=True):
     # For each chart
     for chart in charts:
         chart_location = os.path.dirname(chart)
-        frigate_output = gen(chart_location, format, credits=credits, deps=deps)
+        frigate_output = gen(chart_location, format, credits=credits, deps=deps, skip_dep_repos_refresh=True)
         artifact = Path(chart_location, output_file)
         Path(artifact).touch()
         with open(artifact, "r") as before:

--- a/frigate/tests/test_frigate.py
+++ b/frigate/tests/test_frigate.py
@@ -155,7 +155,7 @@ def test_custom_template(rich_chart_path):
 def test_deps(deps_chart_path):
     from frigate.gen import gen
 
-    docs = gen(deps_chart_path, "markdown")
+    docs = gen(deps_chart_path, "markdown", skip_dep_repos_refresh=True)
 
     assert "simple.image.repository" in docs
     [tag_line] = [line for line in docs.splitlines() if "simple.image.tag" in line]


### PR DESCRIPTION
Hello, this PR lower (maybe a lot) tests execution times when local machine have a lot of remote helm repos (mine has). This is somewhat related to #51 as it lower the time we have to wait for every commit, and implement a new parameter `skip_dep_repos_refresh`, which defaults to False, in order to accomplish that. Hope this helps, ciao!