### PR TITLE
Fix broken rst output when there are parameters longer than 50 symbols

### DIFF
--- a/frigate/templates/rst.jinja2
+++ b/frigate/templates/rst.jinja2
@@ -22,15 +22,20 @@ Configuration
 
 The following table lists the configurable parameters of the {{ name | capitalize }} chart and their default values.
 
-================================================== ==================================================================================================== ==================================================
-Parameter                                          Description                                                                                          Default
-================================================== ==================================================================================================== ==================================================
-{% for (param, comment, default) in values -%}
-{% set param = '``' + param + '``' -%}
-{% set default = '``%s``' | format(default) -%}
-{{ "%-50s" | format(param) }} {{ "%-100s" | format(comment) }} {{ "%-50s" | format(default) }}
-{% endfor -%}
-================================================== ==================================================================================================== ==================================================
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Parameter
+     - Description
+     - Default
+{% for (param, comment, default) in values %}
+{% set param = '``' + param + '``' %}
+{% set default = '``%s``' | format(default) %}
+   * - {{ "%-50s" | format(param) }}
+     - {{ "%-100s" | format(comment) }}
+     - {{ "%-50s" | format(default) }}
+{% endfor %}
 {% endblock -%}
 
 {% block footnotes -%}


### PR DESCRIPTION
Fixes https://github.com/rapidsai/frigate/issues/58

As suggested by @jacobtomlinson, we can move away from table formatting to using list-table directive. Some changes were added to the whitespace formatting in the `for` loop and `set` commands in jinja2 template, so that the indenting is correct and the table is produced