### PR TITLE
Update GitHub Action workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build and upload Frigate python package to PyPI and Conda
+name: build
 
 on:
   push:

--- a/.github/workflows/build_conda_and_pypi.yaml
+++ b/.github/workflows/build_conda_and_pypi.yaml
@@ -10,7 +10,7 @@ defaults:
     shell: bash
 
 jobs:
-  conda-python-build:
+  conda-build:
     runs-on: ubuntu-latest
     container:
       image: condaforge/mambaforge
@@ -32,28 +32,23 @@ jobs:
             RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_TOKEN }}
           fi
           anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --skip-existing --no-progress /tmp/frigate-bld/noarch/*.tar.bz2
-  wheel-build-frigate:
+  wheel-build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install wheel setuptools twine
-
       - name: Build package
         run: python setup.py sdist bdist_wheel
-
       - name: Upload to PyPI
         if: inputs.upload == true
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
         run: $CONDA/bin/conda install -c conda-forge pre-commit
       - name: Run check style
         run: $CONDA/bin/pre-commit run --hook-stage manual --all-files --show-diff-on-failure
-  python-build:
+  build:
     needs: check-style
     name: Build Frigate Package
     uses: ./.github/workflows/build_conda_and_pypi.yaml
@@ -29,5 +29,5 @@ jobs:
   pr-builder:
     needs:
       - check-style
-      - python-build
+      - build
     uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.04


### PR DESCRIPTION
This PR makes a few small changes to the GitHub Action workflows.

Specifically, it:

- Updates the `name` of `build.yaml` to be `build` for consistency with the other RAPIDS repositories
- Makes some job names more consistent
- Makes line breaks more consistent