### PR TITLE
Update `shared-action-workflows` references

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,4 +30,4 @@ jobs:
     needs:
       - check-style
       - build
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.04
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-23.04


### PR DESCRIPTION
Update `shared-action-workflows` references to `shared-actions` following the work to rename the `rapidsai/shared-action-workflows` to `rapidsai/shared-workflows`.