### PR TITLE
Also glob `.conda` packages for `anaconda upload`

### DIFF
--- a/.github/workflows/build_conda_and_pypi.yaml
+++ b/.github/workflows/build_conda_and_pypi.yaml
@@ -31,7 +31,9 @@ jobs:
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_TOKEN }}
           fi
-          anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --skip-existing --no-progress /tmp/frigate-bld/noarch/*.tar.bz2
+          anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --skip-existing --no-progress \
+            /tmp/frigate-bld/noarch/*.tar.bz2 \
+          ;
   wheel-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_conda_and_pypi.yaml
+++ b/.github/workflows/build_conda_and_pypi.yaml
@@ -32,6 +32,7 @@ jobs:
             RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_TOKEN }}
           fi
           anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --skip-existing --no-progress \
+            /tmp/frigate-bld/noarch/*.conda \
             /tmp/frigate-bld/noarch/*.tar.bz2 \
           ;
   wheel-build:


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/build-planning/issues/98

Update the `anaconda upload` line here to include `.conda` packages in addition to `.tar.bz2`. This way both are uploaded.